### PR TITLE
Edited sfl/sflxmll.c via GitHub

### DIFF
--- a/sfl/sflxmll.c
+++ b/sfl/sflxmll.c
@@ -328,7 +328,7 @@ xml_save_string (
     ASSERT (item);
     init_charmaps ();                   /*  Initialise character maps        */
     xml_size = xml_item_size (item);
-    xml_string = mem_alloc (xml_size + 1000);
+    xml_string = mem_alloc (xml_size + 1);
     if (xml_string)
         xml_save_string_item (xml_string, item);
 
@@ -374,7 +374,7 @@ xml_item_size (XML_ITEM *item)
         if ((child = xml_first_child (item)))
           {
             /*  Count '>' and '</name>'                                      */
-            item_size += strlen (name) + 4;
+            item_size += strlen (item_name) + 4;
             for (child  = xml_first_child (item);
                  child != NULL;
                  child  = xml_next_sibling (child))


### PR DESCRIPTION
Wrong size computed in xml_item_size() resulting in a memory corruption under RHEL 5.6 (glibc code validating the fastbin memory in the free()).
A global variable char[] name is used instead of item_name. This results in a buffer where the complete xml string does not fit (the +1000 after the function call only is not sufficient when generating big xml strings).
